### PR TITLE
Unconditionally add ExceptT instances using transformers-compat

### DIFF
--- a/src/Unbound/Generics/LocallyNameless/Fresh.hs
+++ b/src/Unbound/Generics/LocallyNameless/Fresh.hs
@@ -20,9 +20,7 @@ import Control.Monad ()
 import Control.Monad.Identity
 
 import Control.Monad.Trans
-#if MIN_VERSION_transformers(0,4,0)
 import Control.Monad.Trans.Except
-#endif
 import Control.Monad.Trans.Error
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Reader
@@ -100,10 +98,8 @@ instance Monad m => Fresh (FreshMT m) where
 instance (Error e, Fresh m) => Fresh (ErrorT e m) where
   fresh = lift . fresh
 
-#if MIN_VERSION_transformers(0,4,0)
 instance Fresh m => Fresh (ExceptT e m) where
   fresh = lift . fresh
-#endif
 
 instance Fresh m => Fresh (MaybeT m) where
   fresh = lift . fresh

--- a/src/Unbound/Generics/LocallyNameless/LFresh.hs
+++ b/src/Unbound/Generics/LocallyNameless/LFresh.hs
@@ -69,9 +69,7 @@ import Control.Applicative (Applicative, Alternative)
 
 import Control.Monad.Trans.Cont
 import Control.Monad.Trans.Error
-#if MIN_VERSION_transformers(0,4,0)
 import Control.Monad.Trans.Except
-#endif
 import Control.Monad.Trans.Identity
 import Control.Monad.Trans.List
 import Control.Monad.Trans.Maybe
@@ -147,12 +145,10 @@ instance (Error e, LFresh m) => LFresh (ErrorT e m) where
   avoid  = mapErrorT . avoid
   getAvoids = lift getAvoids
 
-#if MIN_VERSION_transformers(0,4,0)
 instance LFresh m => LFresh (ExceptT e m) where
   lfresh = lift . lfresh
   avoid = mapExceptT . avoid
   getAvoids = lift getAvoids
-#endif
 
 instance LFresh m => LFresh (IdentityT m) where
   lfresh = lift . lfresh

--- a/unbound-generics.cabal
+++ b/unbound-generics.cabal
@@ -50,6 +50,7 @@ library
   build-depends:       base >=4.6 && <5,
                        mtl >= 2.1,
                        transformers >= 0.3,
+                       transformers-compat >= 0.3,
                        containers == 0.5.*,
                        contravariant >= 0.5
   hs-source-dirs:      src


### PR DESCRIPTION
This is needed to allow reverse-dependencies of this package to migrate to `ExceptT` while keeping backwards compatibility for older versions of `transformers`.

Also see https://github.com/fpco/stackage/issues/439
