### PR TITLE
Expose GAlpha methods

### DIFF
--- a/src/Unbound/Generics/LocallyNameless/Alpha.hs
+++ b/src/Unbound/Generics/LocallyNameless/Alpha.hs
@@ -27,6 +27,18 @@ module Unbound.Generics.LocallyNameless.Alpha (
   , termCtx
   , isTermCtx
   , incrLevelCtx
+  -- * Internal
+  , gaeq
+  , gfvAny
+  , gclose
+  , gopen
+  , gisPat
+  , gisTerm
+  , gnthPatFind
+  , gnamePatFind
+  , gswaps
+  , gfreshen
+  , glfreshen
   ) where
 
 import Control.Applicative (Applicative(..), (<$>))

--- a/src/Unbound/Generics/LocallyNameless/Name.hs
+++ b/src/Unbound/Generics/LocallyNameless/Name.hs
@@ -65,6 +65,11 @@ s2n = string2Name
 makeName :: String -> Integer -> Name a
 makeName = Fn
 
+-- | Get the integer part of a 'Name'.
+name2Integer :: Name a -> String
+name2Integer (Fn _ i) = i
+name2Integer (Bn _ _) = error "Internal Error: cannot call name2Integer for bound names"
+
 -- | Get the string part of a 'Name'.
 name2String :: Name a -> String
 name2String (Fn s _) = s

--- a/src/Unbound/Generics/LocallyNameless/Name.hs
+++ b/src/Unbound/Generics/LocallyNameless/Name.hs
@@ -66,7 +66,7 @@ makeName :: String -> Integer -> Name a
 makeName = Fn
 
 -- | Get the integer part of a 'Name'.
-name2Integer :: Name a -> String
+name2Integer :: Name a -> Integer
 name2Integer (Fn _ i) = i
 name2Integer (Bn _ _) = error "Internal Error: cannot call name2Integer for bound names"
 

--- a/src/Unbound/Generics/LocallyNameless/Name.hs
+++ b/src/Unbound/Generics/LocallyNameless/Name.hs
@@ -73,7 +73,7 @@ name2Integer (Bn _ _) = error "Internal Error: cannot call name2Integer for boun
 -- | Get the string part of a 'Name'.
 name2String :: Name a -> String
 name2String (Fn s _) = s
-name2String (Bn _ _)   = error "Internal Error: cannot call name2Integer for bound names"
+name2String (Bn _ _) = error "Internal Error: cannot call name2String for bound names"
 
 instance Show (Name a) where
   show (Fn "" n) = "_" ++ (show n)

--- a/src/Unbound/Generics/LocallyNameless/Name.hs
+++ b/src/Unbound/Generics/LocallyNameless/Name.hs
@@ -22,6 +22,7 @@ module Unbound.Generics.LocallyNameless.Name
        , makeName
          -- * Name inspection
        , name2String
+       , name2Integer
          -- * Heterogeneous names
        , AnyName(..)
        ) where


### PR DESCRIPTION
But _only_ the methods, so that we may use GAlpha without being able to create new bogus instances.

I do this, because my situation is the following.
I have a the following data type:
```haskell
-- | Term representation in the CoreHW language: System F + LetRec + Case
data Term
  = Var     Type TmName                    -- ^ Variable reference
  | Data    DataCon                        -- ^ Datatype constructor
  | Literal Literal                        -- ^ Literal
  | Prim    Text Type                      -- ^ Primitive
  | Lam     (Bind Id Term)                 -- ^ Term-abstraction
  | TyLam   (Bind TyVar Term)              -- ^ Type-abstraction
  | App     Term Term                      -- ^ Application
  | TyApp   Term Type                      -- ^ Type-application
  | Letrec  (Bind (Rec [LetBinding]) Term) -- ^ Recursive let-binding
  | Case    Term Type [Bind Pat Term]      -- ^ Case-expression: subject, type of
                                           -- alternatives, list of alternatives
  deriving (Show,Typeable,Generic)
```

Where the `Type` argument of the `Prim` constructor is simply an annotation. During alpha equivalence testing, I want to omit checking this annotation, and still use the `Generic` version of alpha-equality testing for the other constructors:
```haskell
instance Alpha Term where
  aeq' _ (Prim t1 _) (Prim t2 _) = t1 == t2
  aeq' c t1          t2          = gaeq c (from t1) (from t2)
```