### PR TITLE
[ghc-7.6] older GHC doesn't like newer deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.16 GHCVER=7.6.3
+    - env: CABALVER=1.18 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}

--- a/unbound-generics.cabal
+++ b/unbound-generics.cabal
@@ -96,7 +96,7 @@ Benchmark benchmark-unbound-generics
   hs-source-dirs:      benchmarks
   main-is:             benchmark-main.hs
   build-depends:       base
-                     , criterion
+                     , criterion >= 1.0.0.1
                      , deepseq >= 1.3.0.0
                      , deepseq-generics >= 0.1.1.2
                      , unbound-generics

--- a/unbound-generics.cabal
+++ b/unbound-generics.cabal
@@ -96,15 +96,13 @@ Benchmark benchmark-unbound-generics
   hs-source-dirs:      benchmarks
   main-is:             benchmark-main.hs
   build-depends:       base
+                     , criterion
                      , deepseq >= 1.3.0.0
                      , deepseq-generics >= 0.1.1.2
                      , unbound-generics
   if impl (ghc == 7.6.*)
-    build-depends:     criterion >= 1.0.0.1 && < 1.1.1.0
-                     , semigroups <= 0.18.1       
+    build-depends:     semigroups <= 0.18.1       
                      , unix <= 2.6.0.1
-  else
-    build-depends:     criterion
   other-modules:       BenchLam
   ghc-options:       -Wall
 

--- a/unbound-generics.cabal
+++ b/unbound-generics.cabal
@@ -99,9 +99,10 @@ Benchmark benchmark-unbound-generics
                      , deepseq >= 1.3.0.0
                      , deepseq-generics >= 0.1.1.2
                      , unbound-generics
-  if impl (ghc < 7.8)
+  if impl (ghc == 7.6.*)
     build-depends:     criterion >= 1.0.0.1 && < 1.1.1.0
-                     , semigroups <= 0.18.1                      
+                     , semigroups <= 0.18.1       
+                     , unix <= 2.6.0.1
   else
     build-depends:     criterion
   other-modules:       BenchLam

--- a/unbound-generics.cabal
+++ b/unbound-generics.cabal
@@ -101,8 +101,7 @@ Benchmark benchmark-unbound-generics
                      , deepseq-generics >= 0.1.1.2
                      , unbound-generics
   if impl (ghc == 7.6.*)
-    build-depends:     semigroups <= 0.18.1       
-                     , unix <= 2.6.0.1
+    build-depends:     unix <= 2.6.0.1
   other-modules:       BenchLam
   ghc-options:       -Wall
 

--- a/unbound-generics.cabal
+++ b/unbound-generics.cabal
@@ -101,6 +101,7 @@ Benchmark benchmark-unbound-generics
                      , unbound-generics
   if impl (ghc < 7.8)
     build-depends:     criterion < 1.1.1.0
+                     , semigroups <= 0.18.1                      
   else
     build-depends:     criterion
   other-modules:       BenchLam

--- a/unbound-generics.cabal
+++ b/unbound-generics.cabal
@@ -96,10 +96,13 @@ Benchmark benchmark-unbound-generics
   hs-source-dirs:      benchmarks
   main-is:             benchmark-main.hs
   build-depends:       base
-                     , criterion
                      , deepseq >= 1.3.0.0
                      , deepseq-generics >= 0.1.1.2
                      , unbound-generics
+  if impl (ghc < 7.8)
+    build-depends:     criterion < 1.1.1.0
+  else
+    build-depends:     criterion
   other-modules:       BenchLam
   ghc-options:       -Wall
 

--- a/unbound-generics.cabal
+++ b/unbound-generics.cabal
@@ -100,7 +100,7 @@ Benchmark benchmark-unbound-generics
                      , deepseq-generics >= 0.1.1.2
                      , unbound-generics
   if impl (ghc < 7.8)
-    build-depends:     criterion < 1.1.1.0
+    build-depends:     criterion >= 1.0.0.1 && < 1.1.1.0
                      , semigroups <= 0.18.1                      
   else
     build-depends:     criterion


### PR DESCRIPTION
newer criterion pulls in a newer optparse-applicative which pulls in a newer bytestring.