### PR TITLE
Add instances for Monads defined in exceptions

### DIFF
--- a/src/Unbound/Generics/LocallyNameless/Fresh.hs
+++ b/src/Unbound/Generics/LocallyNameless/Fresh.hs
@@ -19,6 +19,7 @@ import Control.Monad ()
 
 import Control.Monad.Identity
 
+import Control.Monad.Catch
 import Control.Monad.Trans
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Error
@@ -53,7 +54,18 @@ class Monad m => Fresh m where
 --   still globally unused, and increments the index every time it is
 --   asked for a fresh name.
 newtype FreshMT m a = FreshMT { unFreshMT :: St.StateT Integer m a }
-  deriving (Functor, Applicative, Alternative, Monad, MonadPlus, MonadIO, MonadFix)
+  deriving
+    ( Functor
+    , Applicative
+    , Alternative
+    , Monad
+    , MonadIO
+    , MonadPlus
+    , MonadFix
+    , MonadThrow
+    , MonadCatch
+    , MonadMask
+    )
 
 -- | Run a 'FreshMT' computation (with the global index starting at zero).
 runFreshMT :: Monad m => FreshMT m a -> m a

--- a/src/Unbound/Generics/LocallyNameless/LFresh.hs
+++ b/src/Unbound/Generics/LocallyNameless/LFresh.hs
@@ -63,6 +63,7 @@ import qualified Data.Set as S
 import Data.Monoid
 import Data.Typeable (Typeable)
 
+import Control.Monad.Catch
 import Control.Monad.Reader
 import Control.Monad.Identity
 import Control.Applicative (Applicative, Alternative)
@@ -102,7 +103,18 @@ class Monad m => LFresh m where
 -- avoid, and when asked for a fresh one will choose the first numeric
 -- prefix of the given name which is currently unused.
 newtype LFreshMT m a = LFreshMT { unLFreshMT :: ReaderT (Set AnyName) m a }
-  deriving (Functor, Applicative, Alternative, Monad, MonadIO, MonadPlus, MonadFix)
+  deriving
+    ( Functor
+    , Applicative
+    , Alternative
+    , Monad
+    , MonadIO
+    , MonadPlus
+    , MonadFix
+    , MonadThrow
+    , MonadCatch
+    , MonadMask
+    )
 
 -- | Run an 'LFreshMT' computation in an empty context.
 runLFreshMT :: LFreshMT m a -> m a

--- a/unbound-generics.cabal
+++ b/unbound-generics.cabal
@@ -61,7 +61,8 @@ library
                        containers == 0.5.*,
                        contravariant >= 0.5,
                        profunctors >= 4.0,
-                       ansi-wl-pprint >= 0.6.7.2 && < 0.7
+                       ansi-wl-pprint >= 0.6.7.2 && < 0.7,
+                       exceptions >= 0.8 && < 0.9
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall


### PR DESCRIPTION
Instances of the exception-related monads in the exceptions package
have been added for the FreshMT and LFreshMT types. This allows these
monads to be used in transformer stacks which make use of extensible
exceptions. For example, a compiler may want a typechecking monad

    newtype CheckM a = C { unCheckM :: StateT TypeEnv FreshM a }

to derive MonadThrow, allowing exceptions to be thrown using a custom
exception type with typechecking-specific exceptions.