### PR TITLE
Use `Data.Map.foldr` instead of `Data.Map.fold`

### DIFF
--- a/src/Unbound/Generics/PermM.hs
+++ b/src/Unbound/Generics/PermM.hs
@@ -119,7 +119,7 @@ isid (Perm p) =
 join :: Ord a => Perm a -> Perm a -> Maybe (Perm a)
 join (Perm p1) (Perm p2) =
      let overlap = M.intersectionWith (==) p1 p2 in
-     if M.fold (&&) True overlap then
+     if M.foldr (&&) True overlap then
        Just (Perm (M.union p1 p2))
        else Nothing
 

--- a/unbound-generics.cabal
+++ b/unbound-generics.cabal
@@ -50,15 +50,15 @@ library
                        Unbound.Generics.LocallyNameless.TH
                        Unbound.Generics.PermM
                        Unbound.Generics.LocallyNameless.Subst
-  -- other-modules:       
-  -- other-extensions:    
+  -- other-modules:
+  -- other-extensions:
   build-depends:       base >=4.6 && <5,
                        template-haskell >= 2.8.0.0,
                        deepseq >= 1.3.0.0,
                        mtl >= 2.1,
                        transformers >= 0.3,
                        transformers-compat >= 0.3,
-                       containers == 0.5.*,
+                       containers >= 0.5 && < 0.7,
                        contravariant >= 0.5,
                        profunctors >= 4.0,
                        ansi-wl-pprint >= 0.6.7.2 && < 0.7,


### PR DESCRIPTION
Given that `fold = foldr` in `containers-0.5`, there shouldn't be any performance differences. This change is needed to build on GHC 8.6 which ships with `containers-0.6`.