### PR TITLE
Add Ignore annotation

### DIFF
--- a/src/Unbound/Generics/LocallyNameless/Ignore.hs
+++ b/src/Unbound/Generics/LocallyNameless/Ignore.hs
@@ -1,0 +1,45 @@
+-- |
+-- Module     : Unbound.Generics.LocallyNameless.Ignore
+-- Copyright  : (c) 2018, Reed Mullanix
+-- License    : BSD3 (See LICENSE)
+-- Maintainer : Reed Mullanix
+-- Stability  : experimental
+--
+-- Ignores a term for the purposes of alpha-equality and substitution
+{-# LANGUAGE DeriveGeneric #-}
+module Unbound.Generics.LocallyNameless.Ignore (
+    Ignore(..)
+    ) where
+
+import Control.DeepSeq (NFData(..))
+
+import GHC.Generics (Generic)
+
+import Unbound.Generics.LocallyNameless.Alpha
+
+-- | Ignores a term 't' for the purpose of alpha-equality and substitution
+data Ignore t = I t
+        deriving (Generic)
+
+instance (NFData t) => NFData (Ignore t) where
+    rnf (I t) = rnf t `seq` ()
+
+instance (Show t) => Show (Ignore t) where
+    showsPrec prec (I t) = 
+        showParen (prec > 0) (showString "<-" 
+                              . showsPrec prec t
+                              . showString "->")
+
+instance (Show t) => Alpha (Ignore t) where
+    aeq' _ _ _ = True
+    fvAny' _ _ = pure
+    isPat _ = inconsistentDisjointSet
+    isTerm _ = mempty
+    close _ _ = id
+    open _ _ = id
+    namePatFind  _ = NamePatFind $ const $ Left 0
+    nthPatFind _ = NthPatFind Left
+    swaps' _ _ = id
+    lfreshen' _ i cont = cont i mempty
+    freshen' _ i = return (i, mempty)
+    acompare' _ _ _ = EQ

--- a/src/Unbound/Generics/LocallyNameless/Ignore.hs
+++ b/src/Unbound/Generics/LocallyNameless/Ignore.hs
@@ -18,7 +18,7 @@ import GHC.Generics (Generic)
 import Unbound.Generics.LocallyNameless.Alpha
 
 -- | Ignores a term 't' for the purpose of alpha-equality and substitution
-data Ignore t = I t
+data Ignore t = I !t
         deriving (Generic)
 
 instance (NFData t) => NFData (Ignore t) where

--- a/src/Unbound/Generics/LocallyNameless/Ignore.hs
+++ b/src/Unbound/Generics/LocallyNameless/Ignore.hs
@@ -12,6 +12,8 @@ module Unbound.Generics.LocallyNameless.Ignore (
     ) where
 
 import Control.DeepSeq (NFData(..))
+import Control.Applicative
+import Data.Monoid 
 
 import GHC.Generics (Generic)
 

--- a/src/Unbound/Generics/LocallyNameless/Operations.hs
+++ b/src/Unbound/Generics/LocallyNameless/Operations.hs
@@ -42,6 +42,7 @@ module Unbound.Generics.LocallyNameless.Operations
        , luntrec
        , Ignore
        , ignore
+       , unignore
        ) where
 
 import Control.Applicative (Applicative)
@@ -220,3 +221,7 @@ luntrec (TRec b) =
 -- | Constructor for ignoring a term for the purposes of alpha-equality and substs
 ignore :: t -> Ignore t
 ignore t = I t
+
+-- | Destructor for ignored terms
+unignore :: Ignore t -> t
+unignore (I t) = t

--- a/src/Unbound/Generics/LocallyNameless/Operations.hs
+++ b/src/Unbound/Generics/LocallyNameless/Operations.hs
@@ -40,6 +40,8 @@ module Unbound.Generics.LocallyNameless.Operations
        , trec
        , untrec
        , luntrec
+       , Ignore
+       , ignore
        ) where
 
 import Control.Applicative (Applicative)
@@ -55,6 +57,7 @@ import Unbound.Generics.LocallyNameless.Bind
 import Unbound.Generics.LocallyNameless.Embed (Embed(..), IsEmbed(..))
 import Unbound.Generics.LocallyNameless.Rebind
 import Unbound.Generics.LocallyNameless.Rec
+import Unbound.Generics.LocallyNameless.Ignore
 import Unbound.Generics.LocallyNameless.Internal.Fold (toListOf, justFiltered)
 import Unbound.Generics.LocallyNameless.Internal.Lens (view)
 import Unbound.Generics.LocallyNameless.Internal.Iso (from)
@@ -213,3 +216,7 @@ untrec (TRec b) = do
 luntrec :: (Alpha p, LFresh m) => TRec p -> m p
 luntrec (TRec b) =
   lunbind b $ \(p, ()) -> return (unrec p)
+
+-- | Constructor for ignoring a term for the purposes of alpha-equality and substs
+ignore :: t -> Ignore t
+ignore t = I t

--- a/src/Unbound/Generics/LocallyNameless/Subst.hs
+++ b/src/Unbound/Generics/LocallyNameless/Subst.hs
@@ -56,6 +56,7 @@ import Unbound.Generics.LocallyNameless.Name
 import Unbound.Generics.LocallyNameless.Alpha
 import Unbound.Generics.LocallyNameless.Embed
 import Unbound.Generics.LocallyNameless.Shift
+import Unbound.Generics.LocallyNameless.Ignore
 import Unbound.Generics.LocallyNameless.Bind
 import Unbound.Generics.LocallyNameless.Rebind
 import Unbound.Generics.LocallyNameless.Rec
@@ -179,3 +180,7 @@ instance (Subst c p1, Subst c p2) => Subst c (Rebind p1 p2)
 instance (Subst c p) => Subst c (Rec p)
 
 instance (Alpha p, Subst c p) => Subst c (TRec p)
+
+instance Subst a (Ignore b) where
+  subst _ _ = id
+  substs _ = id

--- a/test/TestIgnore.hs
+++ b/test/TestIgnore.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric, MultiParamTypeClasses #-}
+{-# LANGUAGE DeriveGeneric, DeriveDataTypeable, MultiParamTypeClasses #-}
 module TestIgnore (test_ignore) where
 
 import Data.Typeable(Typeable)

--- a/test/TestIgnore.hs
+++ b/test/TestIgnore.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE DeriveGeneric, MultiParamTypeClasses #-}
+module TestIgnore (test_ignore) where
+
+import Data.Typeable(Typeable)
+import GHC.Generics (Generic)
+import Unbound.Generics.LocallyNameless
+
+import AlphaAssertions
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+type Var = Name Term
+
+type SourcePos = (Int, Int)
+data SourceSpan = SourceSpan 
+    { start :: SourcePos
+    , end :: SourcePos
+    }
+    deriving (Show)
+
+data Term
+    = Var Var
+    | Lam (Bind Var Term)
+    | App Term Term
+    | Ann (Ignore SourceSpan) Term
+    | NoSubst (Ignore Term)
+    deriving (Show, Typeable, Generic)
+
+instance Alpha Term
+instance Subst Term Term where
+    isvar (Var x) = Just $ SubstName x
+    isvar _ = Nothing
+
+lam :: Var -> Term -> Term
+lam x t = Lam (bind x t)
+
+x :: Var
+x = s2n "x"
+
+y :: Var
+y = s2n "y"
+
+t1 :: Term
+t1 = Ann (ignore (SourceSpan (0,0) (0,1))) (Var x)
+
+t2 :: Term
+t2 = Ann (ignore (SourceSpan (1,0) (1,10))) (Var x)
+
+test_ignore :: TestTree
+test_ignore =
+    testCase "<-(0,0) (0,1)-> x = <-(1,0) (1,10)-> x" $ assertAeq t1 t2

--- a/test/test-main.hs
+++ b/test/test-main.hs
@@ -8,6 +8,7 @@ import PropOpenClose
 import TinyLam
 import TestACompare
 import TestRefine
+import TestIgnore
 import TestShiftEmbed
 import TestTH
 
@@ -18,6 +19,7 @@ main = defaultMain $ testGroup "unboundGenerics"
        , test_parallelReduction
        , test_openClose
        , test_refine
+       , test_ignore
        , test_tinyLam
        , test_acompare
        , test_shiftEmbed

--- a/unbound-generics.cabal
+++ b/unbound-generics.cabal
@@ -82,6 +82,8 @@ Test-Suite test-unbound-generics
                        TestParallelReduction
                        PropOpenClose
                        TinyLam
+                       TestRefine
+                       TestIgnore
                        TestACompare
                        TestShiftEmbed
                        TestTH

--- a/unbound-generics.cabal
+++ b/unbound-generics.cabal
@@ -38,6 +38,7 @@ library
                        Unbound.Generics.LocallyNameless.LFresh
                        Unbound.Generics.LocallyNameless.Alpha
                        Unbound.Generics.LocallyNameless.Bind
+                       Unbound.Generics.LocallyNameless.Ignore
                        Unbound.Generics.LocallyNameless.Rebind
                        Unbound.Generics.LocallyNameless.Embed
                        Unbound.Generics.LocallyNameless.Shift


### PR DESCRIPTION
[moniker](https://github.com/brendanzab/moniker) has a pattern for ignoring parts of an AST for the purposes of substitution and alpha-equality. Normally `makeClosedAlpha` would take its place, but that doesn't play nicely with ASTs that have polymorphic annotations. For example:
```
data Term = ...
    | Ann ann Term
```
The `Alpha` instance for this requires that `ann` have an `Alpha` instance, which is somewhat silly.

This PR adds the `Ignore t` type, which has an `Alpha` instance that always returns True, and a `Subst` instance that is just identity. For reference, the above example would become
```
data Term = ...
    | Ann (Ignore ann) Term
```
