### PR TITLE
Removed Show superclass of Alpha

### DIFF
--- a/src/Unbound/Generics/LocallyNameless/Alpha.hs
+++ b/src/Unbound/Generics/LocallyNameless/Alpha.hs
@@ -157,7 +157,7 @@ isNullDisjointSet _ = False
 --
 -- Minimal instance is entirely empty, provided that your type is an instance of
 -- 'Generic'.
-class (Show a) => Alpha a where
+class Alpha a where
   -- | See 'Unbound.Generics.LocallyNameless.Operations.aeq'.
   aeq' :: AlphaCtx -> a -> a -> Bool
   default aeq' :: (Generic a, GAlpha (Rep a)) => AlphaCtx -> a -> a -> Bool

--- a/src/Unbound/Generics/LocallyNameless/Bind.hs
+++ b/src/Unbound/Generics/LocallyNameless/Bind.hs
@@ -63,8 +63,9 @@ instance (Alpha p, Alpha t) => Alpha (Bind p t) where
   open ctx b (B p t) =
     B (open (patternCtx ctx) b p) (open (incrLevelCtx ctx) b t)
 
-  nthPatFind b = error $ "Binding " ++ show b ++ " used as a pattern"
-  namePatFind b = error $ "Binding " ++ show b ++ " used as a pattern"
+  nthPatFind _ = error "Binding used as a pattern"
+  
+  namePatFind _ = error "Binding used as a pattern"
 
   swaps' ctx perm (B p t) =
     B (swaps' (patternCtx ctx) perm p)

--- a/src/Unbound/Generics/LocallyNameless/Ignore.hs
+++ b/src/Unbound/Generics/LocallyNameless/Ignore.hs
@@ -32,7 +32,7 @@ instance (Show t) => Show (Ignore t) where
                               . showsPrec prec t
                               . showString "->")
 
-instance (Show t) => Alpha (Ignore t) where
+instance Alpha (Ignore t) where
     aeq' _ _ _ = True
     fvAny' _ _ = pure
     isPat _ = inconsistentDisjointSet


### PR DESCRIPTION
Removes the show superclass on Alpha. 
This is a breaking change for users expecting (Alpha a) to imply (Show a).
This also makes bind's error message in namePatFind/nthPatFind less descriptive.
Addresses #36