### PR TITLE
Implement `substBind` function

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # NEXT
 
+* Add `substBind` operation that substitutes for the bound variable of a `Bind (Name a) t` term.
+  This adds a new function `substPat` to the `Subst` class.
+  This is similar to https://github.com/sweirich/replib/commit/98bdb8a2dab991771702597f16d1e1e7fdbd04fe
+  but we don't add a dynamically-typed `substPats` function.
+* Expose `Rec` constructor of the `Rec` type and the `ctxLevel` function from `AlphaCtx`.
+
 * Add `Functor` instance for `Unbound.Generics.LocallyNameless.Internal.Iso.Exchange`
   Thanks to Emily Pillmore (emilypi)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
   This adds a new function `substPat` to the `Subst` class.
   This is similar to https://github.com/sweirich/replib/commit/98bdb8a2dab991771702597f16d1e1e7fdbd04fe
   but we don't add a dynamically-typed `substPats` function.
+* Tests for `substBind` by Mark Lemay (marklemay) Thanks!
 * Expose `Rec` constructor of the `Rec` type and the `ctxLevel` function from `AlphaCtx`.
 
 # 0.4.2

--- a/examples/LC.hs
+++ b/examples/LC.hs
@@ -48,8 +48,7 @@ red (App e1 e2) = do
   e2' <- red e2
   case e1' of
     Lam bnd -> do
-        (x, e1'') <- unbind bnd
-        return $ subst x e2' e1''
+        return $ substBind bnd e2'
     otherwise -> return $ App e1' e2'
 red (Lam bnd) = do
    (x, e) <- unbind bnd
@@ -105,3 +104,4 @@ main = do
   assertM "be3" $ if_ true (Var x) (Var y) =~ Var x
   assertM "be4" $ if_ false (Var x) (Var y) =~ Var y
   assertM "be5" $ App (App plus one) two =~ three
+  print "Done"

--- a/src/Unbound/Generics/LocallyNameless/Alpha.hs
+++ b/src/Unbound/Generics/LocallyNameless/Alpha.hs
@@ -25,6 +25,7 @@ module Unbound.Generics.LocallyNameless.Alpha (
   , NthPatFind(..)
   , NamePatFind(..)
   , AlphaCtx
+  , ctxLevel
   , initialCtx
   , patternCtx
   , termCtx

--- a/src/Unbound/Generics/LocallyNameless/Rec.hs
+++ b/src/Unbound/Generics/LocallyNameless/Rec.hs
@@ -13,7 +13,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Unbound.Generics.LocallyNameless.Rec
        (
-         Rec
+         Rec (Rec)
        , rec
        , unrec
        , TRec (..)

--- a/src/Unbound/Generics/LocallyNameless/Subst.hs
+++ b/src/Unbound/Generics/LocallyNameless/Subst.hs
@@ -46,6 +46,7 @@ module Unbound.Generics.LocallyNameless.Subst (
   SubstName(..)
   , SubstCoerce(..)
   , Subst(..)
+  , substBind
   ) where
 
 import GHC.Generics
@@ -109,31 +110,45 @@ class Subst b a where
     | otherwise =
       error $ "Cannot substitute for bound variable in: " ++ show (map fst ss)
 
+  -- | @substPat ctx v tm@ substitutes for the bound variable @v@ in @tm@ in context @ctx@. See @'substBind'@
+  substPat :: AlphaCtx -> b -> a -> a
+  default substPat :: (Generic a, GSubst b (Rep a)) => AlphaCtx -> b -> a -> a
+  substPat ctx u x =
+    case (isvar x :: Maybe (SubstName a b)) of
+      Just (SubstName (Bn j 0)) | ctxLevel ctx == j -> u
+      _ -> to $ gsubstPat ctx u (from x)
+
 ---- generic structural substitution.
 
 class GSubst b f where
   gsubst :: Name b -> b -> f c -> f c
   gsubsts :: [(Name b, b)] -> f c -> f c
+  gsubstPat :: AlphaCtx -> b -> f c -> f c
 
 instance Subst b c => GSubst b (K1 i c) where
   gsubst nm val = K1 . subst nm val . unK1
   gsubsts ss = K1 . substs ss . unK1
+  gsubstPat ctx val = K1 . substPat ctx val . unK1
 
 instance GSubst b f => GSubst b (M1 i c f) where
   gsubst nm val = M1 . gsubst nm val . unM1
   gsubsts ss = M1 . gsubsts ss . unM1
+  gsubstPat ctx val = M1 . gsubstPat ctx val . unM1
 
 instance GSubst b U1 where
   gsubst _nm _val _ = U1
   gsubsts _ss _ = U1
+  gsubstPat _ctx _val _ = U1
 
 instance GSubst b V1 where
   gsubst _nm _val = id
   gsubsts _ss = id
+  gsubstPat _ctx _val = id
 
 instance (GSubst b f, GSubst b g) => GSubst b (f :*: g) where
   gsubst nm val (f :*: g) = gsubst nm val f :*: gsubst nm val g
   gsubsts ss (f :*: g) = gsubsts ss f :*: gsubsts ss g
+  gsubstPat ctx val (f :*: g) = gsubstPat ctx val f :*: gsubstPat ctx val g
 
 instance (GSubst b f, GSubst b g) => GSubst b (f :+: g) where
   gsubst nm val (L1 f) = L1 $ gsubst nm val f
@@ -142,18 +157,21 @@ instance (GSubst b f, GSubst b g) => GSubst b (f :+: g) where
   gsubsts ss (L1 f) = L1 $ gsubsts ss f
   gsubsts ss (R1 g) = R1 $ gsubsts ss g
 
+  gsubstPat ctx val (L1 f) = L1 $ gsubstPat ctx val f
+  gsubstPat ctx val (R1 g) = R1 $ gsubstPat ctx val g
+
 -- these have a Generic instance, but
 -- it's self-refential (ie: Rep Int = D1 (C1 (S1 (Rec0 Int))))
 -- so our structural GSubst instances get stuck in an infinite loop.
-instance Subst b Int where subst _ _ = id ; substs _ = id
-instance Subst b Bool where subst _ _ = id ; substs _ = id
-instance Subst b () where subst _ _ = id ; substs _ = id
-instance Subst b Char where subst _ _ = id ; substs _ = id
-instance Subst b Float where subst _ _ = id ; substs _ = id
-instance Subst b Double where subst _ _ = id ; substs _ = id
+instance Subst b Int where subst _ _ = id ; substs _ = id ; substPat _ _ = id
+instance Subst b Bool where subst _ _ = id ; substs _ = id ; substPat _ _ = id
+instance Subst b () where subst _ _ = id ; substs _ = id ; substPat _ _ = id
+instance Subst b Char where subst _ _ = id ; substs _ = id ; substPat _ _ = id
+instance Subst b Float where subst _ _ = id ; substs _ = id ; substPat _ _ = id
+instance Subst b Double where subst _ _ = id ; substs _ = id ; substPat _ _ = id
 
 -- huh, apparently there's no instance Generic Integer. 
-instance Subst b Integer where subst _ _ = id ; substs _ = id
+instance Subst b Integer where subst _ _ = id ; substs _ = id ; substPat _ _ = id
 
 instance (Subst c a, Subst c b) => Subst c (a,b)
 instance (Subst c a, Subst c b, Subst c d) => Subst c (a,b,d)
@@ -164,23 +182,34 @@ instance (Subst c a) => Subst c [a]
 instance (Subst c a) => Subst c (Maybe a)
 instance (Subst c a, Subst c b) => Subst c (Either a b)
 
-instance Subst b (Name a) where subst _ _ = id ; substs _ = id
-instance Subst b AnyName where subst _ _ = id ; substs _ = id
+instance Subst b (Name a) where subst _ _ = id ; substs _ = id ; substPat _ _ = id
+instance Subst b AnyName where subst _ _ = id ; substs _ = id ; substPat _ _ = id
 
-instance (Subst c a) => Subst c (Embed a)
+instance (Subst c a) => Subst c (Embed a) where
+  substPat ctx val (Embed t) = Embed (substPat (termCtx ctx) val t)
 
 instance (Subst c e) => Subst c (Shift e) where
   subst x b (Shift e) = Shift (subst x b e)
   substs ss (Shift e) = Shift (substs ss e)
+  substPat ctx val (Shift e) = Shift (substPat (decrLevelCtx ctx) val e)
 
-instance (Subst c b, Subst c a, Alpha a, Alpha b) => Subst c (Bind a b)
+instance (Subst c b, Subst c a, Alpha a, Alpha b) => Subst c (Bind a b) where
+  substPat ctx val (B p t) = B (substPat (patternCtx ctx) val p) (substPat (incrLevelCtx ctx) val t)
 
-instance (Subst c p1, Subst c p2) => Subst c (Rebind p1 p2)
+instance (Subst c p1, Subst c p2) => Subst c (Rebind p1 p2) where
+  substPat ctx val (Rebnd p1 p2) = Rebnd (substPat ctx val p1) (substPat (incrLevelCtx ctx) val p2)
 
-instance (Subst c p) => Subst c (Rec p)
+instance (Subst c p) => Subst c (Rec p) where
+  substPat ctx val (Rec p) = Rec (substPat (incrLevelCtx ctx) val p)
 
 instance (Alpha p, Subst c p) => Subst c (TRec p)
 
 instance Subst a (Ignore b) where
   subst _ _ = id
   substs _ = id
+  substPat _ _ = id
+
+-- | Specialized version of capture-avoiding substitution for that operates on a @'Bind' ('Name' a) t@ term to @'unbind'@
+-- the bound name @Name a@ and immediately subsitute a new term for its occurrences.
+substBind :: Subst a t => Bind (Name a) t -> a -> t
+substBind (B _ t) u = substPat initialCtx u t

--- a/test/AlphaProperties.hs
+++ b/test/AlphaProperties.hs
@@ -1,0 +1,27 @@
+module AlphaProperties where
+
+import Unbound.Generics.LocallyNameless (fv, aeq, Name, Alpha)
+
+import Test.Tasty.QuickCheck (counterexample, Property, testProperty)
+
+import Data.Typeable (Typeable)
+
+import Data.Monoid (Any(..))
+import Unbound.Generics.LocallyNameless.Internal.Fold (foldMapOf, toListOf)
+
+
+
+isFreeIn :: (Typeable a, Alpha b) => Name a -> b -> Bool
+isFreeIn = elementOf fv
+  where
+    elementOf l = anyOf l . (==)
+    anyOf l f = getAny . foldMapOf l (Any . f)
+
+notFreeIn :: (Typeable a, Alpha b) => Name a -> b -> Bool
+notFreeIn v = not . isFreeIn v
+
+(=~=) :: (Alpha a, Show a) => a -> a -> Property
+x =~= y = counterexample (show x ++ " not alpha equivalent to " ++ show y) (x `aeq` y)
+
+(/~@) :: (Typeable a, Alpha b, Show b) => Name a -> b -> Property
+v /~@ t = counterexample (show v ++ " is free in " ++ show t) (v `notFreeIn` t)

--- a/test/PropOpenClose.hs
+++ b/test/PropOpenClose.hs
@@ -13,23 +13,8 @@ import Test.Tasty.QuickCheck (testProperty)
 import Unbound.Generics.LocallyNameless
 import Unbound.Generics.LocallyNameless.Internal.Fold (foldMapOf, toListOf)
 
-----------------------------------------
--- Property testing utilities
+import AlphaProperties
 
-isFreeIn :: (Typeable a, Alpha b) => Name a -> b -> Bool
-isFreeIn = elementOf fv
-  where
-    elementOf l = anyOf l . (==)
-    anyOf l f = getAny . foldMapOf l (Any . f)
-
-notFreeIn :: (Typeable a, Alpha b) => Name a -> b -> Bool
-notFreeIn v = not . isFreeIn v
-
-(=~=) :: (Alpha a, Show a) => a -> a -> Property
-x =~= y = counterexample (show x ++ " not alpha equivalent to " ++ show y) (x `aeq` y)
-
-(/~@) :: (Typeable a, Alpha b, Show b) => Name a -> b -> Property
-v /~@ t = counterexample (show v ++ " is free in " ++ show t) (v `notFreeIn` t)
 
 -- Wrapper around 'Name a' that has an Arbitrary instance that generates free names.
 -- Note that this doesn't guarantee /freshness/.  The name may clash with some other one.

--- a/test/TestSubstBind.hs
+++ b/test/TestSubstBind.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE MultiParamTypeClasses, DeriveGeneric, DeriveDataTypeable #-}
+
+module TestSubstBind  where
+
+import Test.Tasty
+import Unbound.Generics.LocallyNameless
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+
+
+import Test.QuickCheck
+import Test.Tasty.QuickCheck (testProperty)
+import Unbound.Generics.LocallyNameless.Unsafe (unsafeUnbind)
+
+import AlphaProperties 
+
+type Var = Name Expr
+
+data Expr = V Var | Lam (Bind Var Expr) | I Int | App Expr Expr
+  deriving (Generic, Typeable, Show)
+
+instance Alpha Expr
+
+instance Subst Expr Expr where
+  isvar (V x) = Just (SubstName x)
+  isvar _     = Nothing
+
+
+instance Arbitrary Expr where
+  arbitrary = sized arbitrarySizedExpr
+
+  shrink (I i) = I <$> shrink i
+  shrink (Lam bndExp) = 
+    (substBind bndExp <$> [I 0, V x, V y, V z]) -- does the problem persist with the binder removed?
+     ++ (Lam <$> underBinder shrink bndExp) -- shrink under the binder
+  shrink (f `App` a) = [f, a] ++ (App <$> shrink f <*> shrink a)
+  shrink _ = []
+
+underBinder :: (Monad m) => (Expr -> m Expr) -> Bind Var Expr -> m (Bind Var Expr)
+underBinder op bndExp = let 
+  (name, bod) = unsafeUnbind bndExp -- Should be safe since no freshnames are invoked
+  in do
+    bod' <- op bod
+    pure $ bind name bod'
+
+arbitrarySizedExpr :: Int -> Gen Expr
+arbitrarySizedExpr i | i < 1 = do 
+  n <- arbitrary 
+  var <- elements [x,y,z]
+  elements [I n, V $ var]
+arbitrarySizedExpr i = do 
+  rest <- arbitrarySizedExpr (i - 1)
+  var <- elements [x,y,z]
+  n <- arbitrary 
+  f <- arbitrarySizedExpr (i `div` 2) -- TODO: reorganize better
+  a <- arbitrarySizedExpr (i `div` 2)
+  elements [Lam $ bind var rest, f `App` a, I n, V $ var]
+
+
+x,y,z :: Var
+x = s2n "x"
+y = s2n "y"
+z = s2n "z"
+
+
+smallStep :: Expr -> Maybe Expr
+smallStep ((Lam bndBod) `App` a) = Just $ substBind bndBod a
+smallStep (f `App` a) = 
+  case (smallStep f, smallStep a) of
+    (Nothing, Nothing) -> Nothing
+    (Just f', _) -> Just $ f' `App` a
+    (Nothing, Just a') -> Just $ f `App` a'
+smallStep (Lam bndBod) = Lam <$> underBinder smallStep bndBod
+smallStep _ = Nothing -- no step
+
+
+smallStep' :: (Fresh m) => Expr -> m (Maybe Expr)
+smallStep' ((Lam bndBod) `App` a) = do
+  (name, bod) <- unbind bndBod
+  pure $ Just $ subst name a bod
+smallStep' (f `App` a) = do
+  mf' <- smallStep' f
+  ma' <- smallStep' a
+  case (mf', ma') of
+    (Nothing, Nothing) -> pure $ Nothing
+    (Just f', _) -> pure $ Just $ f' `App` a
+    (Nothing, Just a') -> pure $ Just $ f `App` a'
+smallStep' (Lam bndBod) = do
+  (name, bod) <- unbind bndBod
+  mbod' <- smallStep' bod
+  case mbod' of
+    Nothing -> pure $ Nothing
+    Just bod' -> pure $ Just $ Lam $ bind name bod'
+smallStep' _ = pure $ Nothing -- no step
+
+
+expbindProp ::  Expr -> Property
+expbindProp e = smallStep e =~= runFreshM (smallStep' e)
+
+test_substBind :: TestTree
+test_substBind = testGroup "substBind"
+          [testProperty "substBind matches unbind subst" $ expbindProp]

--- a/test/test-main.hs
+++ b/test/test-main.hs
@@ -11,6 +11,7 @@ import TestRefine
 import TestIgnore
 import TestShiftEmbed
 import TestTH
+import TestSubstBind
 
 main :: IO ()
 main = defaultMain $ testGroup "unboundGenerics"
@@ -24,4 +25,5 @@ main = defaultMain $ testGroup "unboundGenerics"
        , test_acompare
        , test_shiftEmbed
        , test_TH
+       , test_substBind
        ]

--- a/unbound-generics.cabal
+++ b/unbound-generics.cabal
@@ -87,6 +87,8 @@ Test-Suite test-unbound-generics
                        TestACompare
                        TestShiftEmbed
                        TestTH
+                       TestSubstBind
+                       AlphaProperties
   build-depends:       base,
                        mtl,
                        tasty,


### PR DESCRIPTION
I had to expose a couple of functions that were previously not exported (`ctxLevel` and the `Rec` term constructor), which will need a version bump.

Addresses https://github.com/lambdageek/unbound-generics/issues/16

---

I had to do more work than https://github.com/sweirich/replib/commit/98bdb8a2dab991771702597f16d1e1e7fdbd04fe
Specifically, I was surprised that the `substPat` function for the `Rebind`, `Shift`, `Embed`, and `Rec` instances did not manipulate the `AlphaCtx` in the Unbound version of this function.  That seems like a bug in `Unbound`. /cc @sweirich

