### PR TITLE
import MonadPlus and MonadFix explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # os: [ubuntu-latest, macOS-latest, windows-latest]
         os: [ ubuntu-latest ]
-        cabal: ["3.2"]
+        cabal: ["3.4"]
         ghc:
           - "7.10"
           - "8.0"
@@ -26,6 +26,7 @@ jobs:
           - "8.6"
           - "8.8"
           - "8.10"
+          - "9.0"
         # exclude:
         #   - os: macOS-latest
         #     ghc: 8.8
@@ -40,7 +41,7 @@ jobs:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1.1
+    - uses: haskell/actions/setup@v1.2
       id: setup-haskell-cabal
       name: Setup Haskell
       with:
@@ -51,11 +52,15 @@ jobs:
       run: |
         cabal freeze
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       name: Cache ~/.cabal/store
       with:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
         key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+
+    - name: Install dependencies
+      run: |
+        cabal build all --only-dependencies
 
     - name: Build
       run: |
@@ -65,6 +70,10 @@ jobs:
     - name: Test
       run: |
         cabal test all
+
+    - name: Documentation
+      run: |
+        cabal haddock        
 
   # stack:
   #   name: stack / ghc ${{ matrix.ghc }}

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 * Add `Functor` instance for `Unbound.Generics.LocallyNameless.Internal.Iso.Exchange`
   Thanks to Emily Pillmore (emilypi)
+* Import `MonadPlus` and `MonadFix` explicitly when building with mtl-2.3
+* Builds with GHC 9.0
 
 # 0.4.1
 

--- a/src/Unbound/Generics/LocallyNameless/Fresh.hs
+++ b/src/Unbound/Generics/LocallyNameless/Fresh.hs
@@ -24,6 +24,10 @@ import Control.Monad.Catch (MonadThrow, MonadCatch, MonadMask)
 #if MIN_VERSION_base(4,9,0)
 import qualified Control.Monad.Fail as Fail
 #endif
+#if MIN_VERSION_mtl(2,3,0)
+import Control.Monad (MonadPlus)
+import Control.Monad.Fix (MonadFix)
+#endif
 import Control.Monad.Trans
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Error

--- a/src/Unbound/Generics/LocallyNameless/LFresh.hs
+++ b/src/Unbound/Generics/LocallyNameless/LFresh.hs
@@ -68,6 +68,10 @@ import Control.Monad.Catch (MonadThrow, MonadCatch, MonadMask)
 #if MIN_VERSION_base(4,9,0)
 import qualified Control.Monad.Fail as Fail
 #endif
+#if MIN_VERSION_mtl(2,3,0)
+import Control.Monad (MonadPlus)
+import Control.Monad.Fix (MonadFix)
+#endif
 import Control.Monad.Reader
 import Control.Monad.Identity
 import Control.Applicative (Applicative, Alternative)

--- a/unbound-generics.cabal
+++ b/unbound-generics.cabal
@@ -29,7 +29,7 @@ extra-source-files:  examples/*.hs, examples/*.lhs,
                      README.md,
                      Changelog.md
 cabal-version:       >=1.10
-tested-with: GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.*
+tested-with: GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.*, GHC == 9.0.*
              
 library
   exposed-modules:     Unbound.Generics.LocallyNameless


### PR DESCRIPTION
it doesn't leak out of mtl exports anymore in mtl-2.3

Fixes #44 

Add GHC-9.0.2 to CI build matrix; update github actions