### PR TITLE
Add  'instantiate' operation to substitute a list of terms for a toplevel 'Bind pat term'

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,11 +1,11 @@
 # NEXT
 
+* Add an `instantiate` function that substitutes a list of terms for a collection of bound variables in a toplevel `Bind p t` term.
+  Thanks to Stephanie Weirich (sweirich).  This adds a new `substBvs` function to the `Subst` class.
 * Add `substBind` operation that substitutes for the bound variable of a `Bind (Name a) t` term.
-  This adds a new function `substPat` to the `Subst` class.
-  This is similar to https://github.com/sweirich/replib/commit/98bdb8a2dab991771702597f16d1e1e7fdbd04fe
-  but we don't add a dynamically-typed `substPats` function.
+  This is a specialization of `instantiate` to the case where the pattern is a single `Name a`
 * Tests for `substBind` by Mark Lemay (marklemay) Thanks!
-* Expose `Rec` constructor of the `Rec` type and the `ctxLevel` function from `AlphaCtx`.
+* Expose `Rec` constructor of the `Rec` type and the `ctxLevel` function from `AlphaCtx`
 
 # 0.4.2
 

--- a/examples/F.hs
+++ b/examples/F.hs
@@ -26,14 +26,14 @@ type TmName = Name Tm
 
 data Ty = TyVar TyName
         | Arr Ty Ty
-        | All (Bind TyName Ty)
+        | All (Bind [TyName] Ty)
    deriving (Show, Generic, Typeable)
 
 data Tm = TmVar TmName
         | Lam (Bind (TmName, Embed Ty) Tm)
-        | TLam (Bind TyName Tm)
+        | TLam (Bind [TyName] Tm)
         | App Tm Tm
-        | TApp Tm Ty
+        | TApp Tm [Ty]
    deriving (Show, Generic, Typeable)
 
 ------------------------------------------------------
@@ -65,20 +65,30 @@ c :: Name Ty
 
 -- /\a. \x:a. x
 polyid :: Tm
-polyid = TLam (bind a (Lam (bind (x, Embed (TyVar a)) (TmVar x))))
+polyid = TLam (bind [a] (Lam (bind (x, Embed (TyVar a)) (TmVar x))))
 
 -- All a. a -> a
 polyidty :: Ty
-polyidty = All (bind a (Arr (TyVar a) (TyVar a)))
+polyidty = All (bind [a] (Arr (TyVar a) (TyVar a)))
 
 -- /\b. \y:b. y
 polyid2 :: Tm
-polyid2 = TLam (bind b (Lam (bind (y, Embed (TyVar b)) (TmVar y))))
+polyid2 = TLam (bind [b] (Lam (bind (y, Embed (TyVar b)) (TmVar y))))
 
 -- /\c. \y:b. y
 bad_polyid2 :: Tm
-bad_polyid2 = TLam (bind c (Lam (bind (y, Embed (TyVar b)) (TmVar y))))
+bad_polyid2 = TLam (bind [c] (Lam (bind (y, Embed (TyVar b)) (TmVar y))))
 
+-- /\a b. a -> b -> a
+const_ty :: Ty
+const_ty = All (bind [a,b] (Arr (TyVar a) (Arr (TyVar b) (TyVar a))))
+
+-- /\a b. a -> b -> a
+const_tm :: Tm
+const_tm = TLam (bind [a,b] (Lam (bind (x, Embed (TyVar a)) (Lam (bind (y, Embed (TyVar b)) (TmVar x))))))
+
+test :: Ty
+test = fst (runM (ti emptyCtx (TApp const_tm [polyidty, All (bind [c] (TyVar c))])))
 
 -----------------------------------------------------------------
 -- Typechecker
@@ -112,8 +122,8 @@ lookupTmVar g v = do
       Just s -> return s
       Nothing -> throwError "NotFound"
 
-extendTy :: TyName -> Ctx -> Ctx
-extendTy n ctx = ctx { getDelta =  n : (getDelta ctx) }
+extendTy :: [TyName] -> Ctx -> Ctx
+extendTy ns ctx = ctx { getDelta =  ns <> (getDelta ctx) }
 
 extendTm :: TmName -> Ty -> Ctx -> Ctx
 extendTm n ty ctx = ctx { getGamma = (n, ty) : (getGamma ctx) }
@@ -162,9 +172,8 @@ ti g (TApp t ty) = do
   tyt <- ti g t
   case tyt of
    (All bnder) -> do
-      tcty g  ty
-      (n1, ty1) <- unbind bnder
-      return $ subst n1 ty ty1
+      mapM_ (tcty g) ty
+      return $ instantiate bnder ty
    _ -> throwError $ "Expected a ForAll in a type application, got " ++ show tyt
 
 

--- a/src/Unbound/Generics/LocallyNameless/Alpha.hs
+++ b/src/Unbound/Generics/LocallyNameless/Alpha.hs
@@ -33,6 +33,7 @@ module Unbound.Generics.LocallyNameless.Alpha (
   , incrLevelCtx
   , decrLevelCtx
   , isZeroLevelCtx
+  , ctxLevel
   -- * Internal
   , gaeq
   , gfvAny

--- a/src/Unbound/Generics/LocallyNameless/Subst.hs
+++ b/src/Unbound/Generics/LocallyNameless/Subst.hs
@@ -47,6 +47,7 @@ module Unbound.Generics.LocallyNameless.Subst (
   , SubstCoerce(..)
   , Subst(..)
   , substBind
+  , instantiate
   ) where
 
 import GHC.Generics
@@ -69,6 +70,14 @@ data SubstName a b where
 -- | See 'isCoerceVar'  
 data SubstCoerce a b where  
   SubstCoerce :: Name b -> (b -> Maybe a) -> SubstCoerce a b
+
+-- | Immediately substitute for the bound variables of a pattern
+-- in a binder, without first naming the variables.
+-- NOTE: this operation does not check that the number of terms passed in
+-- match the number of variables in the pattern. (Or that they are of appropriate type.)
+instantiate :: (Alpha a, Alpha b, Alpha p, Subst a b) => Bind p b -> [a] -> b
+instantiate (B _p t) u = substBvs initialCtx u t
+
 
 -- | Instances of @'Subst' b a@ are terms of type @a@ that may contain
 -- variables of type @b@ that may participate in capture-avoiding
@@ -110,45 +119,48 @@ class Subst b a where
     | otherwise =
       error $ "Cannot substitute for bound variable in: " ++ show (map fst ss)
 
-  -- | @substPat ctx v tm@ substitutes for the bound variable @v@ in @tm@ in context @ctx@. See @'substBind'@
-  substPat :: AlphaCtx -> b -> a -> a
-  default substPat :: (Generic a, GSubst b (Rep a)) => AlphaCtx -> b -> a -> a
-  substPat ctx u x =
-    case (isvar x :: Maybe (SubstName a b)) of
-      Just (SubstName (Bn j 0)) | ctxLevel ctx == j -> u
-      _ -> to $ gsubstPat ctx u (from x)
+   -- Bound variable substitution (replace a single pattern variable with a list of terms)
+   -- Similar to open, but replaces with b's instead of with names
+   -- Does not check whether enough b's are provided: will ignore extra if there are too many
+   -- and skip the substitution if there are too few.
+  substBvs :: AlphaCtx -> [b] -> a -> a
+  default substBvs :: (Generic a, GSubst b (Rep a)) => AlphaCtx -> [b] -> a -> a
+  substBvs ctx bs x =
+     case (isvar x :: Maybe (SubstName a b)) of
+        Just (SubstName (Bn j k)) | ctxLevel ctx == j, fromInteger k < length bs -> bs !! fromInteger k
+        _ -> to $ gsubstBvs ctx bs (from x)
 
 ---- generic structural substitution.
 
 class GSubst b f where
   gsubst :: Name b -> b -> f c -> f c
   gsubsts :: [(Name b, b)] -> f c -> f c
-  gsubstPat :: AlphaCtx -> b -> f c -> f c
+  gsubstBvs :: AlphaCtx -> [b] -> f c -> f c
 
 instance Subst b c => GSubst b (K1 i c) where
   gsubst nm val = K1 . subst nm val . unK1
   gsubsts ss = K1 . substs ss . unK1
-  gsubstPat ctx val = K1 . substPat ctx val . unK1
+  gsubstBvs ctx b = K1 . substBvs ctx b . unK1
 
 instance GSubst b f => GSubst b (M1 i c f) where
   gsubst nm val = M1 . gsubst nm val . unM1
   gsubsts ss = M1 . gsubsts ss . unM1
-  gsubstPat ctx val = M1 . gsubstPat ctx val . unM1
+  gsubstBvs c b = M1 . gsubstBvs c b . unM1
 
 instance GSubst b U1 where
   gsubst _nm _val _ = U1
   gsubsts _ss _ = U1
-  gsubstPat _ctx _val _ = U1
+  gsubstBvs _c _b _ = U1
 
 instance GSubst b V1 where
   gsubst _nm _val = id
   gsubsts _ss = id
-  gsubstPat _ctx _val = id
+  gsubstBvs _c _b = id
 
 instance (GSubst b f, GSubst b g) => GSubst b (f :*: g) where
   gsubst nm val (f :*: g) = gsubst nm val f :*: gsubst nm val g
   gsubsts ss (f :*: g) = gsubsts ss f :*: gsubsts ss g
-  gsubstPat ctx val (f :*: g) = gsubstPat ctx val f :*: gsubstPat ctx val g
+  gsubstBvs c b (f :*: g) = gsubstBvs c b f :*: gsubstBvs c b g
 
 instance (GSubst b f, GSubst b g) => GSubst b (f :+: g) where
   gsubst nm val (L1 f) = L1 $ gsubst nm val f
@@ -157,21 +169,21 @@ instance (GSubst b f, GSubst b g) => GSubst b (f :+: g) where
   gsubsts ss (L1 f) = L1 $ gsubsts ss f
   gsubsts ss (R1 g) = R1 $ gsubsts ss g
 
-  gsubstPat ctx val (L1 f) = L1 $ gsubstPat ctx val f
-  gsubstPat ctx val (R1 g) = R1 $ gsubstPat ctx val g
+  gsubstBvs c b (L1 f) = L1 $ gsubstBvs c b f
+  gsubstBvs c b (R1 g) = R1 $ gsubstBvs c b g
 
 -- these have a Generic instance, but
 -- it's self-refential (ie: Rep Int = D1 (C1 (S1 (Rec0 Int))))
 -- so our structural GSubst instances get stuck in an infinite loop.
-instance Subst b Int where subst _ _ = id ; substs _ = id ; substPat _ _ = id
-instance Subst b Bool where subst _ _ = id ; substs _ = id ; substPat _ _ = id
-instance Subst b () where subst _ _ = id ; substs _ = id ; substPat _ _ = id
-instance Subst b Char where subst _ _ = id ; substs _ = id ; substPat _ _ = id
-instance Subst b Float where subst _ _ = id ; substs _ = id ; substPat _ _ = id
-instance Subst b Double where subst _ _ = id ; substs _ = id ; substPat _ _ = id
+instance Subst b Int where subst _ _ = id ; substs _ = id ; substBvs _ _ = id
+instance Subst b Bool where subst _ _ = id ; substs _ = id ; substBvs _ _ = id
+instance Subst b () where subst _ _ = id ; substs _ = id ; substBvs _ _ = id
+instance Subst b Char where subst _ _ = id ; substs _ = id ; substBvs _ _ = id
+instance Subst b Float where subst _ _ = id ; substs _ = id ; substBvs _ _ = id
+instance Subst b Double where subst _ _ = id ; substs _ = id ; substBvs _ _ = id
 
 -- huh, apparently there's no instance Generic Integer. 
-instance Subst b Integer where subst _ _ = id ; substs _ = id ; substPat _ _ = id
+instance Subst b Integer where subst _ _ = id ; substs _ = id ; substBvs _ _ = id
 
 instance (Subst c a, Subst c b) => Subst c (a,b)
 instance (Subst c a, Subst c b, Subst c d) => Subst c (a,b,d)
@@ -182,34 +194,41 @@ instance (Subst c a) => Subst c [a]
 instance (Subst c a) => Subst c (Maybe a)
 instance (Subst c a, Subst c b) => Subst c (Either a b)
 
-instance Subst b (Name a) where subst _ _ = id ; substs _ = id ; substPat _ _ = id
-instance Subst b AnyName where subst _ _ = id ; substs _ = id ; substPat _ _ = id
+instance Subst b (Name a) where subst _ _ = id  ; substs _ = id ; substBvs _ _ = id
+instance Subst b AnyName where subst _ _ = id ; substs _ = id ; substBvs _ _ = id
 
 instance (Subst c a) => Subst c (Embed a) where
-  substPat ctx val (Embed t) = Embed (substPat (termCtx ctx) val t)
+  substBvs c us (Embed x)
+    | isTermCtx c = Embed (substBvs (termCtx c) us x)
+    | otherwise = error "Internal error: substBvs on Embed"
 
 instance (Subst c e) => Subst c (Shift e) where
   subst x b (Shift e) = Shift (subst x b e)
   substs ss (Shift e) = Shift (substs ss e)
-  substPat ctx val (Shift e) = Shift (substPat (decrLevelCtx ctx) val e)
+  substBvs c b (Shift e) = Shift (substBvs (decrLevelCtx c) b e)
 
 instance (Subst c b, Subst c a, Alpha a, Alpha b) => Subst c (Bind a b) where
-  substPat ctx val (B p t) = B (substPat (patternCtx ctx) val p) (substPat (incrLevelCtx ctx) val t)
+  substBvs c b (B p t) = B (substBvs (patternCtx c) b p) (substBvs (incrLevelCtx c) b t)
 
 instance (Subst c p1, Subst c p2) => Subst c (Rebind p1 p2) where
-  substPat ctx val (Rebnd p1 p2) = Rebnd (substPat ctx val p1) (substPat (incrLevelCtx ctx) val p2)
+  substBvs c us (Rebnd p q) = Rebnd (substBvs c us p) (substBvs (incrLevelCtx c) us q)
 
 instance (Subst c p) => Subst c (Rec p) where
-  substPat ctx val (Rec p) = Rec (substPat (incrLevelCtx ctx) val p)
+  substBvs c us (Rec p) = Rec (substBvs (incrLevelCtx c) us p)
 
-instance (Alpha p, Subst c p) => Subst c (TRec p)
+instance (Alpha p, Subst c p) => Subst c (TRec p) where
+  substBvs c us (TRec p) = TRec (substBvs (patternCtx (incrLevelCtx c)) us p)
 
 instance Subst a (Ignore b) where
   subst _ _ = id
   substs _ = id
-  substPat _ _ = id
+  substBvs _ _ = id
 
 -- | Specialized version of capture-avoiding substitution for that operates on a @'Bind' ('Name' a) t@ term to @'unbind'@
 -- the bound name @Name a@ and immediately subsitute a new term for its occurrences.
+--
+-- This is a specialization of @'instantiate' :: Bind pat term -> [a] -> term@ where the @'Bind' pat term@ has a pattern that is just
+-- a single @'Name' a@ and there is a single substitution term of type @a@.  Unlike 'instantiate', this function cannot fail at runtime.
 substBind :: Subst a t => Bind (Name a) t -> a -> t
-substBind (B _ t) u = substPat initialCtx u t
+substBind b u = instantiate b [u]
+

--- a/src/Unbound/Generics/LocallyNameless/Subst.hs
+++ b/src/Unbound/Generics/LocallyNameless/Subst.hs
@@ -75,8 +75,12 @@ data SubstCoerce a b where
 -- in a binder, without first naming the variables.
 -- NOTE: this operation does not check that the number of terms passed in
 -- match the number of variables in the pattern. (Or that they are of appropriate type.)
-instantiate :: (Alpha a, Alpha b, Alpha p, Subst a b) => Bind p b -> [a] -> b
-instantiate (B _p t) u = substBvs initialCtx u t
+instantiate :: (Alpha a, Alpha b, Alpha p , Subst a b) => Bind p b -> [a] -> b
+instantiate bnd u = instantiate_ bnd u
+
+-- | A version of 'instantiate' with a more general type
+instantiate_ :: Subst a b => Bind p b -> [a] -> b
+instantiate_ (B _p t) u = substBvs initialCtx u t
 
 
 -- | Instances of @'Subst' b a@ are terms of type @a@ that may contain
@@ -230,5 +234,5 @@ instance Subst a (Ignore b) where
 -- This is a specialization of @'instantiate' :: Bind pat term -> [a] -> term@ where the @'Bind' pat term@ has a pattern that is just
 -- a single @'Name' a@ and there is a single substitution term of type @a@.  Unlike 'instantiate', this function cannot fail at runtime.
 substBind :: Subst a t => Bind (Name a) t -> a -> t
-substBind b u = instantiate b [u]
+substBind b u = instantiate_ b [u]
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-6.13
+resolver: lts-18.28
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Merge https://github.com/sweirich/unbound-generics/tree/instantiate  Fixes #48 

Re-implement `substBind` as a one-name type-safe specialization of `instantiate`.

