### PR TITLE
Add `Alpha` and `Subst` instances for `NonEmpty`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           - "9.0"
           - "9.2"
           - "9.4"
+          - "9.8"
         # exclude:
         #   - os: macOS-latest
         #     ghc: 8.8

--- a/src/Unbound/Generics/LocallyNameless/Alpha.hs
+++ b/src/Unbound/Generics/LocallyNameless/Alpha.hs
@@ -60,6 +60,7 @@ import Data.Function (on)
 import Data.Functor.Contravariant (Contravariant(..))
 import Data.Foldable (Foldable(..))
 import Data.List (intersect)
+import Data.List.NonEmpty (NonEmpty)
 import Data.Monoid (Monoid(..), All(..))
 import Data.Ratio (Ratio)
 import Data.Semigroup as Sem
@@ -687,6 +688,7 @@ instance Alpha Bool
 
 instance Alpha a => Alpha (Maybe a)
 instance Alpha a => Alpha [a]
+instance Alpha a => Alpha (NonEmpty a)
 instance Alpha ()
 instance (Alpha a,Alpha b) => Alpha (Either a b)
 instance (Alpha a,Alpha b) => Alpha (a,b)

--- a/src/Unbound/Generics/LocallyNameless/Subst.hs
+++ b/src/Unbound/Generics/LocallyNameless/Subst.hs
@@ -53,6 +53,7 @@ module Unbound.Generics.LocallyNameless.Subst (
 import GHC.Generics
 
 import Data.List (find)
+import Data.List.NonEmpty (NonEmpty)
 
 import Unbound.Generics.LocallyNameless.Name
 import Unbound.Generics.LocallyNameless.Alpha
@@ -195,6 +196,7 @@ instance (Subst c a, Subst c b, Subst c d, Subst c e) => Subst c (a,b,d,e)
 instance (Subst c a, Subst c b, Subst c d, Subst c e, Subst c f) =>
    Subst c (a,b,d,e,f)
 instance (Subst c a) => Subst c [a]
+instance (Subst c a) => Subst c (NonEmpty a)
 instance (Subst c a) => Subst c (Maybe a)
 instance (Subst c a, Subst c b) => Subst c (Either a b)
 

--- a/unbound-generics.cabal
+++ b/unbound-generics.cabal
@@ -28,7 +28,7 @@ extra-source-files:  examples/*.hs, examples/*.lhs,
                      README.md,
                      Changelog.md
 
-tested-with: GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.*, GHC == 9.4.*
+tested-with: GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.*, GHC == 9.4.*
 
 library
   exposed-modules:     Unbound.Generics.LocallyNameless
@@ -52,7 +52,7 @@ library
                        Unbound.Generics.LocallyNameless.Subst
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.6 && <5,
+  build-depends:       base >=4.9 && <5,
                        template-haskell >= 2.8.0.0,
                        deepseq >= 1.3.0.0,
                        mtl >= 2.1,

--- a/unbound-generics.cabal
+++ b/unbound-generics.cabal
@@ -28,7 +28,7 @@ extra-source-files:  examples/*.hs, examples/*.lhs,
                      README.md,
                      Changelog.md
 
-tested-with: GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.*, GHC == 9.4.*
+tested-with: GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.*, GHC == 9.4.*, GHC == 9.8.*
 
 library
   exposed-modules:     Unbound.Generics.LocallyNameless


### PR DESCRIPTION
`NonEmpty` has been in `base` since version 4.9, so accepting this PR probably requires changing the lower bound on `base` in the `.cabal` file as well as removing GHC 7.8 and 7.10 from the `tested-with` list, OR including the `NonEmpty` instances conditionally, via CPP.  I'm not sure what your policy is on support for older versions of `base`/GHC so I'll leave that up to you!

Especially with the additional warnings generated by GHC 9.8 for the use of partial functions like `head`, it is nice to be able to use `NonEmpty` when we statically know a list cannot be empty.  For example, I was refactoring some code where I have a function definition that contains a list of clauses --- but in fact it should really be a `NonEmpty` list since every definition must have at least one clause.  After making the refactoring, I ran into the lack of `Alpha` and `Subst` instances.  I put in some derived orphan instances for the moment but figured it would be nice to send these upstream.