### PR TITLE
update from haskell/actions/setup to haskell-actions/setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup-haskell-cabal
       name: Setup Haskell
       with:


### PR DESCRIPTION
the former was unmaintained

this gets us Cabal 3.10.2.1 and GHC 9.8.2 support